### PR TITLE
support not creating collections for networks

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -107,7 +107,7 @@ class ThePornDBAgent(Agent.Movies):
 
                 site_id = scene_data['site']['id']
                 network_id = scene_data['site']['network_id']
-                if network_id and site_id != network_id:
+                if network_id and site_id != network_id and Prefs['collections_from_networks']:
                     uri = API_SITE_URL % network_id
 
                     try:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -12,6 +12,12 @@
         "default": "false"
     },
     {
+        "id": "collections_from_networks",
+        "label": "Collections from Networks",
+        "type": "bool",
+        "default": "true"
+    },
+    {
         "id": "custom_title",
         "label": "Title format",
         "type": "text",


### PR DESCRIPTION
Allows users to not create collections for networks.   Studios will still result in collections.   This will prevent things like adding videos for Tushy in to the Vixen collection as studios and networks are not differentied.