### PR TITLE
Added Option to Automatically Mark Content as Collected When Matched

### DIFF
--- a/ThePornDBMovies.bundle/Contents/Code/__init__.py
+++ b/ThePornDBMovies.bundle/Contents/Code/__init__.py
@@ -6,6 +6,7 @@ API_BASE_URL = 'https://api.metadataapi.net'
 API_SEARCH_URL = API_BASE_URL + '/movies?parse=%s&hash=%s'
 API_MOVIE_URL = API_BASE_URL + '/movies/%s'
 API_SITE_URL = API_BASE_URL + '/sites/%s'
+API_ADD_TO_COLLECTION_QS_SUFFIX = '?add_to_collection=true'
 
 ID_REGEX = r'(:?.*https\:\/\/api\.metadataapi\.net\/movies\/)?(?P<id>[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12})'
 
@@ -86,6 +87,9 @@ class ThePornDBMoviesAgent(Agent.Movies):
 
     def update(self, metadata, media, lang):
         uri = API_MOVIE_URL % metadata.id
+        
+        if Prefs['save_to_collection']:
+            uri = uri + API_ADD_TO_COLLECTION_QS_SUFFIX
 
         try:
             json_obj = GetJSON(uri)

--- a/ThePornDBMovies.bundle/Contents/DefaultPrefs.json
+++ b/ThePornDBMovies.bundle/Contents/DefaultPrefs.json
@@ -52,5 +52,11 @@
         "label": "Replace regex to ...",
         "type": "text",
         "default": ""
+    },
+    {
+        "id": "save_to_collection",
+        "label": "Enable Tagging Content as Collected",
+        "type": "bool",
+        "default": "false"
     }
 ]

--- a/ThePornDBScenes.bundle/Contents/Code/__init__.py
+++ b/ThePornDBScenes.bundle/Contents/Code/__init__.py
@@ -7,6 +7,7 @@ API_BASE_URL = 'https://api.metadataapi.net'
 API_SEARCH_URL = API_BASE_URL + '/scenes?parse=%s&hash=%s'
 API_SCENE_URL = API_BASE_URL + '/scenes/%s'
 API_SITE_URL = API_BASE_URL + '/sites/%s'
+API_ADD_TO_COLLECTION_QS_SUFFIX = '?add_to_collection=true'
 
 ID_REGEX = r'(:?.*https\:\/\/api\.metadataapi\.net\/scenes\/)?(?P<id>[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12})'
 
@@ -109,6 +110,9 @@ class ThePornDBScenesAgent(Agent.Movies):
 
     def update(self, metadata, media, lang):
         uri = API_SCENE_URL % metadata.id
+
+        if Prefs['save_to_collection']:
+            uri = uri + API_ADD_TO_COLLECTION_QS_SUFFIX
 
         try:
             json_obj = GetJSON(uri)

--- a/ThePornDBScenes.bundle/Contents/DefaultPrefs.json
+++ b/ThePornDBScenes.bundle/Contents/DefaultPrefs.json
@@ -74,7 +74,14 @@
         "label": "Replace regex to ...",
         "type": "text",
         "default": ""
-    },    {
+    },
+    {
+        "id": "save_to_collection",
+        "label": "Enable Tagging Content as Collected",
+        "type": "bool",
+        "default": "false"
+    },
+    {
         "id": "debug_logging",
         "label": "Enable Debug logging",
         "type": "bool",


### PR DESCRIPTION
I added it for myself and thought others might like it.

It just flags the scene/movie as collected in tpdb, so you can then filter by collected/not collected more easily in the UI.